### PR TITLE
[add]customer information edit

### DIFF
--- a/app/assets/stylesheets/public/customers.scss
+++ b/app/assets/stylesheets/public/customers.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/customers controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,0 +1,29 @@
+class Public::CustomersController < ApplicationController
+  def show
+  end
+
+  def edit
+    @customer = current_customer
+  end
+
+  def update
+    @customer = current_customer
+    if @customer.update(customer_params)
+      flash[:customer_information_update] = "変更内容を保存しました"
+      redirect_to customers_my_page_path
+    else
+      render :edit
+    end
+  end
+
+  def confirm
+  end
+
+  def leave
+  end
+
+  private
+  def customer_params
+    params.require(:customer).permit(:email, :last_name, :first_name, :last_name_reading, :first_name_reading, :post_code, :address, :phone_number)
+  end
+end

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Public::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_permitted_parameters, if: :devise_controller?
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
@@ -59,4 +60,10 @@ class Public::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :last_name, :first_name, :last_name_reading, :first_name_reading, :post_code, :address, :phone_number])
+  end
+
 end

--- a/app/helpers/public/customers_helper.rb
+++ b/app/helpers/public/customers_helper.rb
@@ -1,0 +1,2 @@
+module Public::CustomersHelper
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -4,6 +4,15 @@ class Customer < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  validates :email, presence: true
+  validates :last_name, presence: true
+  validates :first_name, presence: true
+  validates :last_name_reading, presence: true, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/}
+  validates :first_name_reading, presence: true, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/}
+  validates :post_code, presence: true
+  validates :address, presence: true
+  validates :phone_number, presence: true
+
   has_many :shipping_addresses, dependent: :destroy
   has_many :cart_items, dependent: :destroy
   has_many :orders, dependent: :destroy

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,0 +1,48 @@
+<div class="container">
+  <div class="row">
+    <div class="col-1"></div>
+    <div class="col-10 col-offset-1">
+      <h5 class="my-3 px-4 bg-secondary">会員情報編集</h5>
+        <%= form_with model: @customer, url: customers_information_edit_path, method: :patch do |f| %>
+          <table class="table">
+            <tbody>
+              <tr>
+                <td>氏名</td>
+                <td><%= f.text_field :last_name %></td>
+                <td><%= f.text_field :first_name %></td>
+              </tr>
+              <tr>
+                <td>フリガナ</td>
+                <td><%= f.text_field :last_name_reading %></td>
+                <td><%= f.text_field :first_name_reading %></td>
+              </tr>
+              <tr>
+                <td>郵便番号</td>
+                <td><%= f.text_field :post_code %></td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>住所</td>
+                <td colspan="2"><%= f.text_field :address %></td>
+              </tr>
+              <tr>
+                <td>電話番号</td>
+                <td><%= f.text_field :phone_number %></td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>メールアドレス</td>
+                <td><%= f.email_field :email %></td>
+                <td></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td><%= f.submit "編集内容を保存" %></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -3,7 +3,7 @@
     <div class="col-1"></div>
     <div class="col-10 col-offset-1">
       <h5 class="my-3 px-4 bg-secondary">新規会員登録</h5>
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= form_with model: @customer, url: customer_registration_path do |f| %>
         <%= render "public/shared/error_messages", resource: resource %>
         <table class="table">
           <tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     get "about" => "homes#about"
     get 'customers/my_page' => 'customers#show'
     get 'customers/information/edit' => 'customers#edit'
-    patch 'customers/information' => 'customers#update'
+    patch 'customers/information/edit' => 'customers#update'
     get 'customers/confirm' => 'customers#confirm'
     patch 'customers/leave' => 'customers#leave'
     resources :items, only: [:index, :show]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,6 +50,8 @@ ActiveRecord::Schema.define(version: 2023_07_17_061338) do
     t.string "last_name_reading", null: false
     t.string "first_name_reading", null: false
     t.string "phone_number", null: false
+    t.string "post_code", null: false
+    t.string "address", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"

--- a/test/controllers/public/customers_controller_test.rb
+++ b/test/controllers/public/customers_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Public::CustomersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
実装内容
・顧客情報編集機能追加
・顧客情報編集機能に関わる部分のバリデーションをcustomerモデルに追記
・public/registrationコントローラにbefore_actionを追記
　→本来サインアップ機能のブランチで実装すべき部分ですが、メンター対応にて編集済みにしてしまった為、こちらでマージします

未実装内容
・退会処理に関して
　→別ブランチで実装します
・体裁は最低限です