### PR TITLE
[add]顧客退会機能の実装

### DIFF
--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -20,10 +20,15 @@ class Public::CustomersController < ApplicationController
   end
 
   def leave
+    @customer = current_customer
+    @customer.update(is_deleted: true)
+    reset_session
+    flash[:left] = "退会しました"
+    redirect_to root_path
   end
 
   private
   def customer_params
-    params.require(:customer).permit(:email, :last_name, :first_name, :last_name_reading, :first_name_reading, :post_code, :address, :phone_number)
+    params.require(:customer).permit(:email, :last_name, :first_name, :last_name_reading, :first_name_reading, :post_code, :address, :phone_number, :is_deleted)
   end
 end

--- a/app/views/public/customers/confirm.html.erb
+++ b/app/views/public/customers/confirm.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+  <div class ="row">
+    <div class ="col-3"></div>
+    <div class ="col-6 col-offset-3">
+      <h1 class="my-3 px-4 bg-warning text-danger">本当に退会しますか？</h1>
+      <p>退会すると、会員登録情報や<br>
+         これまでの購入履歴が閲覧できなくなります。<br>
+         退会する場合は、「退会する」をクリックしてください。</p>
+      <%= link_to "退会しない", customers_my_page_path, class:"btn btn-primary" %>
+      <%= link_to "退会する", customers_leave_path, method: :patch, data: {confirm: "本当に退会しますか？"}, class:"btn btn-danger" %>
+    </div>
+  </div>
+</div>

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -38,7 +38,7 @@
               <tr>
                 <td></td>
                 <td><%= f.submit "編集内容を保存" %></td>
-                <td></td>
+                <td><%= link_to "退会する", customers_confirm_path %></td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
customerの退会機能を実装しました
・退会確認画面・機能の作成
・顧客情報編集画面に退会確認画面のリンク作成
・体裁は最低限です
・退会時のフラッシュメッセージをコントローラ側に作成しましたが、ビュー側（redirect先はルートページ）には実装していません。
　