### PR TITLE
[add]管理者_商品一覧画面

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'devise'
 gem "enum_help"
 
 gem 'kaminari','~> 1.2.1'
+gem 'bootstrap5-kaminari-views', '~> 0.0.1'
 
 gem 'pry-byebug', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
+    bootstrap5-kaminari-views (0.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.39.2)
@@ -260,6 +263,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  bootstrap5-kaminari-views (~> 0.0.1)
   byebug
   capybara (>= 3.26)
   devise

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ItemsController < ApplicationController
   def index
-    items = Item.all
+    @items = Item.page(params[:page]).per(10)
   end
 
   def new

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,7 +1,41 @@
 <div class= "container">
   <div class="row mt-5">
+    <h4 class="col-4 text-center bg-light">商品一覧</h4>
+    <div class="col-1 offset-7">
     <%= link_to new_admin_item_path do %>
       <i class="fa-regular fa-square-plus fa-2xl" style="color: #000000;"></i>
     <% end %>
+    </div>
   </div>
+
+  <br>
+  <table class="table">
+    <thead>
+      <tr class="bg-light">
+        <th>商品ID</th>
+        <th>商品名</th>
+        <th>税抜価格</th>
+        <th>ジャンル</th>
+        <th>ステータス</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @items.each do |item| %>
+        <tr>
+          <td><%= item.id %></td>
+          <td><u><%=link_to item.name, admin_item_path(item), class: "text-dark" %></u></td>
+          <td><%= number_to_currency(item.price, precision: 0, unit: "") %></td>
+          <td><%= item.genre.name %></td>
+          <td>
+            <% if item.is_active %><div class="text-success font-weight-bold">販売中</div>
+            <% else %><div class="text-secondary font-weight-bold">販売停止中</div>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <div class="col-2 offset-5 mt-5"><%= paginate @items, theme: 'bootstrap-5' %></div>
+
 </div>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,41 +1,43 @@
-<!--グリッドシステムのコードが見づらいので、後ほどテーブルにする！-->
-<h1>商品詳細</h1>
 <div class="container">
-<div class="row">
-<div class="col-4">
-  <%= image_tag @item.get_item_image, size:'200x200' %>
-</div>
-<div class="col-8">
-  <div class="row">
-    <div class="col-3">商品名</div>
-    <div class="col-9"><%= @item.name %></div>
-  </div>
-  <div class="row">
-    <div class="col-3">商品説明</div>
-    <div class="col-9"><%= @item.explanation %></div>
-  </div>
-  <div class="row">
-    <div class="col-3">ジャンル</div>
-    <div class="col-9"><%= Genre.find(@item.genre_id).name %></div>
-  </div>
-  <div class="row">
-    <div class="col-3">税込み価格<br>（税抜価格）</div>
-    <div class="col-9">
-      <%= number_to_currency(@item.price, format: "%n%u", unit: "円", precision: 0) %>
-      （<%= number_to_currency(@item.price*1.1, format: "%n%u", unit: "円", precision: 0) %>）
+  <h4 class="col-lg-3 text-center bg-light mt-4">商品詳細</h1>
+
+  <div class="row mt-5">
+    <div class="col-lg-3">
+      <%= image_tag @item.get_item_image, size:'200x200' %>
+    </div>
+    <div class="col-8">
+      <div class="row mt-3 mt-lg-2">
+        <p class="col-lg-3">商品名</p>
+        <h5 class="col-lg-9"><%= @item.name %></h5>
+      </div>
+      <div class="row mt-3 mt-lg-2">
+        <p class="col-lg-3">商品説明</p>
+        <h5 class="col-lg-9"><%= @item.explanation %></h5>
+      </div>
+      <div class="row mt-3 mt-lg-2">
+        <p class="col-lg-3">ジャンル</p>
+        <h5 class="col-lg-9"><%= Genre.find(@item.genre_id).name %></h5>
+      </div>
+      <div class="row mt-3 mt-lg-2">
+        <p class="col-lg-3">税込み価格<br>（税抜価格）</p>
+        <h5 class="col-lg-9 mt-2">
+          <%= number_to_currency(@item.price, format: "%n%u", unit: "", precision: 0) %>
+          （<%= number_to_currency(@item.with_tax_price, format: "%n%u", unit: "", precision: 0) %>）円
+        </h5>
+      </div>
+      <div class="row mt-3 mt-lg-2">
+        <p class="col-lg-3">販売ステータス</p>
+        <h5 class="col-lg-9">
+          <% if @item.is_active %><b class="text-success">販売中</b>
+          <% else %><b class="text-secondary">販売中止</b>
+          <% end %>
+        </h5>
+      </div>
+      <div class="row mt-4 text-center">
+        <div class="col-auto offset-lg-2">
+          <%= link_to "編集する", edit_admin_item_path(@item), class: "btn btn-success" %>
+        </div>
+      </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-3">販売ステータス</div>
-    <div class="col-9">
-      <% if @item.is_active %>販売中
-      <% else %>販売中止
-      <% end %>
-    </div>
-  </div>
-  <div class="row">
-    <%= link_to "編集する", edit_admin_item_path(@item), class: "btn btn-success" %>
-  </div>
-</div>
-</div>
 </div>


### PR DESCRIPTION
## 概要
管理者機能の、商品一覧画面を追加しました。

## 変更
- [add]商品一覧画面（管理者）
- [fix]商品詳細画面のレイアウト（管理者）
- [add]kaminariのbootstrap導入用gem

## 参考
- 追加gemについて
[kaminariを使用してbootstrap5でCSSを追加する](https://qiita.com/mocomou_/items/c3cce91c241e08f9a50b)

## 留意点
- 上記gemを適用する際は、pull後にbundle installを行うこと