### PR TITLE
[fix]商品画像表示機能の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -131,6 +134,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.18.1)
     msgpack (1.7.1)
@@ -201,6 +205,8 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.5)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -268,6 +274,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   devise
   enum_help
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   jquery-rails
   kaminari (~> 1.2.1)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,8 +10,15 @@ class Item < ApplicationRecord
 
   has_one_attached :item_image
 
+  # 商品画像取得ver.1
   def get_item_image
     (item_image.attached?) ? item_image : 'no_image.jpg'
+  end
+
+  # 商品画像取得ver.2
+  def get_item_image2(width, height)
+    (item_image.attached?) ? item_image : 'no_image.jpg'
+    item_image.variant(resize_to_limit: [width, height]).processed
   end
 
   def with_tax_price

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -3,7 +3,7 @@
 
   <div class="row mt-5">
     <div class="col-lg-3">
-      <%= image_tag @item.get_item_image, size:'200x200' %>
+      <%= image_tag @item.get_item_image2(200, 200) %>
     </div>
     <div class="col-8">
       <div class="row mt-3 mt-lg-2">

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -8,7 +8,7 @@
 <% @items.each do |item| %>
 <div class="col-lg-3">
 <%= link_to item_path(item) do %>
-<%= image_tag item.get_item_image, size:'200x150' %>
+<%= image_tag item.get_item_image2(200, 150) %>
 <% end %>
 <br>
 <%= item.name %>


### PR DESCRIPTION
## 概要
Itemモデルのメソッド「get_item_image」を改造した「get_item_image2」を導入しました。

## 変更点
- gemfileに、image_processingを追加（参考：「アプリケーションを完成させよう2、1章」）
- 「get_item_image2」メソッドを新しく導入

## get_item_image2の特徴
- 画像が横に引き伸ばされることがない
- indexなど、複数の画像を表示する際のページ読み込みが早い（画像のリサイズをviewでなくサーバー側で行う）

## get_item_image2の使い方
1. bundle installを行う
2. 「～.get_item_image, size: ("100x100")」としていた表記を、「～.get_item_image2(100, 100)」に直す
