### PR TITLE
[fix]顧客情報編集機能、ログイン機能の修正

### DIFF
--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -60,6 +60,11 @@ class Public::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  def after_sign_up_path_for(resource)
+    customers_my_page_path
+  end
+
   protected
 
   def configure_permitted_parameters

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -20,4 +20,14 @@ class Customer < ApplicationRecord
   def address_display
     '〒' + post_code + ' ' + address + ' ' + last_name + first_name
   end
+
+  def active_for_authentication?
+    super ^ self.is_deleted?
+  end
+
+#非アクティブアカウントでのログイン失敗時にエラーメッセージを出したいが、うまくいかないので残存課題とする
+#  def inactive_message
+#    is_deleted? == false ? super : :deleted
+#  end
+
 end

--- a/app/views/admin/customers/_edit_customer.html.erb
+++ b/app/views/admin/customers/_edit_customer.html.erb
@@ -84,7 +84,7 @@
       <tr>
         <td></td>
         <td><%= f.submit "編集内容を保存", class:"btn btn-success" %></td>
-        <td></td>
+        <td><%= link_to "退会する", customers_confirm_path, class:"btn btn-danger" %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,4 +1,3 @@
-<%= flash[:deleted] %>
 <div class="container">
   <div class="row">
     <div class="col-2"></div>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<%= flash[:deleted] %>
 <div class="container">
   <div class="row">
     <div class="col-2"></div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -44,6 +44,7 @@ ja:
       timeout: セッションがタイムアウトしました。もう一度ログインしてください。
       unauthenticated: ログインもしくはアカウント登録してください。
       unconfirmed: メールアドレスの本人確認が必要です。
+      deleted: 退会されたアカウントです。
     mailer:
       confirmation_instructions:
         action: メールアドレスの確認


### PR DESCRIPTION
# 顧客情報編集機能の修正内容
- 会員情報編集画面に退会画面へのリンクを作成(confirmアクション)

# ログイン機能の修正内容
- 退会済みユーザーがログインできないように修正
　customerモデルにis_deletedカラムがtrueの時にログインできなくなるようコードを追記しました
　有効/退会済み/未登録 ユーザーでログインテストし、正常に機能することを確認しています
- 退会済みユーザーのログイン失敗時のエラーメッセージを表示させようとしましたが、機能していません
　要件にはないのでとりあえずそのまま実装、エラーメッセージは残存課題とします
- 参考ページhttps://qiita.com/m-ito27/items/ddf79b7ec7752168f976